### PR TITLE
Add cash flow list to main page

### DIFF
--- a/src/frontend/app/components/cash-flow.js
+++ b/src/frontend/app/components/cash-flow.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+
+  /**
+   * True if this cash flow is a withdrawal, i.e., less than zero.
+   */
+  isWithdrawal: Ember.computed.lt('cashflow.amount', 0),
+
+  /**
+   * True if this cash flow is a deposit, i.e., zero or greater.
+   */
+  isDeposit: Ember.computed.gte('cashflow.amount', 0),
+});

--- a/src/frontend/app/components/cash-flow.js
+++ b/src/frontend/app/components/cash-flow.js
@@ -1,14 +1,39 @@
 import Ember from 'ember';
+import moment from 'moment';
+import numeral from 'numeral';
 
 export default Ember.Component.extend({
 
   /**
    * True if this cash flow is a withdrawal, i.e., less than zero.
    */
-  isWithdrawal: Ember.computed.lt('cashflow.amount', 0),
+  isWithdrawal: Ember.computed.lt('cashFlow.amount', 0),
 
   /**
    * True if this cash flow is a deposit, i.e., zero or greater.
    */
-  isDeposit: Ember.computed.gte('cashflow.amount', 0),
+  isDeposit: Ember.computed.gte('cashFlow.amount', 0),
+
+  interval: Ember.computed('cashFlow.frequency', function() {
+    var frequency = this.get('cashFlow.frequency');
+    if (frequency == 'once') {
+      return 'on ' + moment(this.get('cashFlow.date')).format('YYYY-MM-DD');
+    } else if (frequency == 'monthly') {
+      var offset = this.get('cashFlow.frequencyOffset');
+      var whichDay;
+      
+      if (offset > 0) {
+        whichDay = numeral(offset).format('Oo');
+      } else {
+        if (offset == -1) {
+          whichDay = 'last';
+        } else {
+          whichDay = numeral(-offset).format('Oo') + ' to last';
+        }
+      }
+
+      return 'on the ' + whichDay + ' day';
+    }
+    return this.get('cashFlow.frequencyOffset');
+  }),
 });

--- a/src/frontend/app/models/cashflow.js
+++ b/src/frontend/app/models/cashflow.js
@@ -7,7 +7,7 @@ export default DS.Model.extend({
   // once, weekly, monthly
   frequency: DS.attr(),
   // for repeated flows, numeric offset into interval (or offset from end)
-  frequency_offset: DS.attr(),
+  frequencyOffset: DS.attr(),
   // date on which one-time events occur
   date: DS.attr(),
 });

--- a/src/frontend/app/templates/components/cash-flow.hbs
+++ b/src/frontend/app/templates/components/cash-flow.hbs
@@ -1,11 +1,11 @@
 {{#paper-item class="md-2-line" as |controls|}}
   {{paper-icon (if isDeposit "attach-money" "money-off")}}
   <div class="md-list-item-text">
-    <h3>{{cashflow.title}}</h3>
+    <h3>{{cashFlow.title}}</h3>
     <p>
-      {{format-money (abs cashflow.amount)}} 
+      {{format-money (abs cashFlow.amount)}} 
       {{if isWithdrawal "withdrawn" "deposited"}}
-      {{cashflow.frequency}}
+      {{cashFlow.frequency}} {{interval}}
     </p>
     {{#controls.button secondary=true iconButton=true}}
       {{paper-icon "mode-edit"}}

--- a/src/frontend/app/templates/components/cash-flow.hbs
+++ b/src/frontend/app/templates/components/cash-flow.hbs
@@ -1,0 +1,15 @@
+{{#paper-item class="md-2-line" as |controls|}}
+  {{paper-icon (if isDeposit "attach-money" "money-off")}}
+  <div class="md-list-item-text">
+    <h3>{{cashflow.title}}</h3>
+    <p>
+      {{format-money (abs cashflow.amount)}} 
+      {{if isWithdrawal "withdrawn" "deposited"}}
+      {{cashflow.frequency}}
+    </p>
+    {{#controls.button secondary=true iconButton=true}}
+      {{paper-icon "mode-edit"}}
+    {{/controls.button}}
+  </div>
+{{/paper-item}}
+

--- a/src/frontend/app/templates/doughflow.hbs
+++ b/src/frontend/app/templates/doughflow.hbs
@@ -1,4 +1,10 @@
 
 <div class="layout-column layout-margin">
     {{cash-flow-chart startingBalance=100}}
+
+    {{#paper-list}}
+        {{#each model as |flow|}}
+            {{cash-flow cashflow=flow}}
+        {{/each}}
+    {{/paper-list}}
 </div>

--- a/src/frontend/app/templates/doughflow.hbs
+++ b/src/frontend/app/templates/doughflow.hbs
@@ -4,7 +4,7 @@
 
     {{#paper-list}}
         {{#each model as |flow|}}
-            {{cash-flow cashflow=flow}}
+            {{cash-flow cashFlow=flow}}
         {{/each}}
     {{/paper-list}}
 </div>

--- a/src/frontend/mirage/config.js
+++ b/src/frontend/mirage/config.js
@@ -11,7 +11,7 @@ export default function() {
           title: 'Paycheck',
           amount: 100,
           frequency: 'monthly',
-          frequencyOffset: '15',
+          'frequency-offset': '15',
         }
       }, {
         type: 'cashflow',
@@ -20,7 +20,7 @@ export default function() {
           title: 'Paycheck',
           amount: 100,
           frequency: 'monthly',
-          frequencyOffset: '-1',
+          'frequency-offset': '-1',
         }
       }, {
         type: 'cashflow',
@@ -29,7 +29,7 @@ export default function() {
           title: 'Amex',
           amount: -120,
           frequency: 'monthly',
-          frequencyOffset: '-1',
+          'frequency-offset': '-3',
         }
       }, {
         type: 'cashflow',

--- a/src/frontend/tests/integration/components/cash-flow-test.js
+++ b/src/frontend/tests/integration/components/cash-flow-test.js
@@ -1,0 +1,30 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('cash-flow', 'Integration | Component | cash flow', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  //this.render(hbs`{{cash-flow}}`);
+
+  //assert.equal(this.$().text().trim(), '');
+
+  this.render(hbs`hi`);
+  assert.equal(this.$().text().trim(), 'hi');
+
+  // Template block usage:
+  /*
+  this.render(hbs`
+    {{#cash-flow}}
+      template block text
+    {{/cash-flow}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+  */
+});


### PR DESCRIPTION
Adds a list of cash flow entries, and their frequencies, to the main page.

Also fixes casing for multi-word models & json-api response.

![screenshot from 2017-05-24 01-21-37](https://cloud.githubusercontent.com/assets/352005/26393690/6f1c5252-401f-11e7-86b5-88d7bedb2d4b.png)
