### PR TITLE
Wire cash flow chart to daily balance objects

### DIFF
--- a/src/frontend/app/models/daily-balance.js
+++ b/src/frontend/app/models/daily-balance.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  date: DS.attr(),
+  balance: DS.attr(),
+
+});

--- a/src/frontend/app/routes/doughflow.js
+++ b/src/frontend/app/routes/doughflow.js
@@ -1,7 +1,13 @@
 import Ember from 'ember';
+import RSVP from 'rsvp';
 
 export default Ember.Route.extend({
   model() {
-    return this.get('store').findAll('cashflow');
-  }
+    return RSVP.hash({
+      cashflows: this.get('store').findAll('cashflow'),
+      dailyBalances: this.get('store').findAll('daily-balance'),
+    });
+  },
+
 });
+

--- a/src/frontend/app/templates/doughflow.hbs
+++ b/src/frontend/app/templates/doughflow.hbs
@@ -1,9 +1,9 @@
 
 <div class="layout-column layout-margin">
-    {{cash-flow-chart startingBalance=100}}
+    {{cash-flow-chart startingBalance=100 dailyBalances=model.dailyBalances}}
 
     {{#paper-list}}
-        {{#each model as |flow|}}
+        {{#each model.cashflows as |flow|}}
             {{cash-flow cashFlow=flow}}
         {{/each}}
     {{/paper-list}}

--- a/src/frontend/mirage/config.js
+++ b/src/frontend/mirage/config.js
@@ -1,3 +1,6 @@
+
+import moment from 'moment';
+
 export default function() {
   this.namespace = '/api';
 
@@ -41,6 +44,36 @@ export default function() {
           date: '2017-06-02',
         }
       }]
+    };
+  });
+
+  this.get('/daily-balances', function() {
+    var points = [];
+    var startDate = new Date('2017-05-24');
+
+    var seed = 1;
+    var myRandom = function() {
+      var x = Math.sin(seed++) * 10000;
+      return x - Math.floor(x);
+    };
+
+    [...Array(90).keys()].map((offset) => {
+      var date = new Date();
+      date.setDate(startDate.getDate() + offset);
+      date = moment(date);
+
+      points.push({
+        type: 'daily-balance',
+        id: date.format('YYYYMMDD'),
+        attributes: {
+          date: date.format('YYYY-MM-DD'),
+          balance: Math.floor(myRandom() * (500 + 500)) - 500,
+        },
+      });
+    });
+
+    return {
+      data: points
     };
   });
 }

--- a/src/frontend/tests/unit/models/daily-balance-test.js
+++ b/src/frontend/tests/unit/models/daily-balance-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('daily-balance', 'Unit | Model | daily balance', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});


### PR DESCRIPTION
Add model for daily-balance, a representation of the balance on a given day. (to be computed by server) Update Mirage data to include dummy-generated daily balances.

Wire cash flow chart to daily balance objects.

![screenshot from 2017-05-25 14-20-33](https://cloud.githubusercontent.com/assets/352005/26471436/8839a6f8-4156-11e7-8f6d-a45c891b3b43.png)
